### PR TITLE
As the response for getting friends and getting friend requests don't…

### DIFF
--- a/Filmatch/Core/Extensions/Mappers.swift
+++ b/Filmatch/Core/Extensions/Mappers.swift
@@ -131,37 +131,31 @@ extension PersonMovieCreditsResponse {
 }
 
 extension FriendshipSingleResponse {
-  func toOtterMatchUser() -> OtterMatchUser {
-    .init(
-      email: nil,
-      username: self.user.username,
-      uid: self.user.uid,
-      photoUrl: self.user.photoUrl,
-      friendshipStatus: self.user.friendshipStatus
-    )
+  func toOtterMatchUser(as status: FriendshipStatus? = nil) -> OtterMatchUser {
+    self.user.toOtterMatchUser(as: status)
   }
 }
 
 extension [FriendshipSingleResponse] {
-  func toOtterMatchUsers() -> [OtterMatchUser] {
-    self.map { $0.toOtterMatchUser() }
+  func toOtterMatchUsers(as status: FriendshipStatus? = .notRelated) -> [OtterMatchUser] {
+    self.map { $0.toOtterMatchUser(as: status) }
   }
 }
 
 extension [OtterMatchUserResponse] {
   func toOtterMatchUsers() -> [OtterMatchUser] {
-    self.map { $0.toOtterMatchUser() }
+    self.map { $0.toOtterMatchUser(as: nil) }
   }
 }
 
 extension OtterMatchUserResponse {
-  func toOtterMatchUser() -> OtterMatchUser {
+  func toOtterMatchUser(as status: FriendshipStatus? = nil) -> OtterMatchUser {
     .init(
       email: self.email ?? "",
       username: self.username,
       uid: self.uid,
       photoUrl: self.photoUrl ?? "",
-      friendshipStatus: self.friendshipStatus
+      friendshipStatus: self.friendshipStatus ?? status
     )
   }
 }

--- a/Filmatch/ViewModel/FriendsViewModel.swift
+++ b/Filmatch/ViewModel/FriendsViewModel.swift
@@ -46,7 +46,7 @@ final class FriendsViewModel {
     
     switch friendsResult {
     case .success(let response):
-      self.friends.setUsers(response.results.toOtterMatchUsers())
+      self.friends.setUsers(response.results.toOtterMatchUsers(as: .friend))
       self.totalFriendsPages = response.totalPages
       self.currentFriendsPage += 1
     case .failure(let error):
@@ -64,7 +64,7 @@ final class FriendsViewModel {
     
     switch friendRequestsResult {
     case .success(let response):
-      self.friendRequests.setUsers(response.results.toOtterMatchUsers())
+      self.friendRequests.setUsers(response.results.toOtterMatchUsers(as: .received))
       self.totalFriendRequestsPages = response.totalPages
       self.currentFriendRequestsPage += 1
     case .failure(let error):


### PR DESCRIPTION
… include the friendship status (because they're obvious), we've included a mapper to assign a friendship status after parsing the response.